### PR TITLE
Adds SourceLink support for better debugging

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Restore tools
         run: dotnet tool restore
-        
+
       - name: Run Slopwatch
         run: dotnet tool run slopwatch analyze --fail-on error
 
@@ -51,7 +51,7 @@ jobs:
       - name: Determine Version
         uses: gittools/actions/gitversion/execute@v4.2.0
         id: gitversion
-      
+
       - name: Generate Release Notes for nuget
         id: plain-notes
         env:
@@ -71,7 +71,7 @@ jobs:
           echo "release-notes<<EOF" >> $GITHUB_OUTPUT
           cat notes.md >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-      
+
       - name: Display GitVersion outputs
         run: |
           echo "Version: ${{ steps.gitversion.outputs.semVer }}"
@@ -86,6 +86,7 @@ jobs:
           --no-restore
           ${{ env.PROJECT_PATH }} 
           /p:Version=${{ steps.gitversion.outputs.semVer }}
+          /p:ContinuousIntegrationBuild=true
 
       - name: Run tests
         run: >
@@ -112,7 +113,9 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: nuget-packages
-          path: ${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.nupkg
+          path: |
+            ${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.nupkg
+            ${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.snupkg
 
   publish:
     permissions:

--- a/src/Signal.Bot/Internal/QueryParameterRegistry.cs
+++ b/src/Signal.Bot/Internal/QueryParameterRegistry.cs
@@ -1,0 +1,6 @@
+namespace Signal.Bot.Internal;
+
+public class QueryParameterRegistry
+{
+    
+}

--- a/src/Signal.Bot/Signal.Bot.csproj
+++ b/src/Signal.Bot/Signal.Bot.csproj
@@ -11,11 +11,17 @@
         <RepositoryType>git</RepositoryType>
         <Copyright>Copyright (c) 2025-$([System.DateTime]::Now.Year) st0o0</Copyright>
     </PropertyGroup>
-
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>true</IsPackable>
+    </PropertyGroup>
+    <PropertyGroup>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <DebugType>embedded</DebugType>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
     <ItemGroup>
         <None Include="../../README.md" Pack="true" Visible="false" PackagePath="\"/>


### PR DESCRIPTION
Improves the debugging experience by enabling SourceLink.

This change configures the project to publish repository URL, embed untracked sources, include symbols, and use the 'snupkg' symbol package format. It also sets the ContinuousIntegrationBuild property to true during the build process and includes snupkg files in the artifact upload.