### PR TITLE
Adds Dependabot groups for better dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,44 @@
 version: 2
-
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "11:00"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "11:00"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
-- package-ecosystem: nuget
-  directory: "/src"
-  schedule:
-    interval: daily
-    time: "11:00"
+  - package-ecosystem: nuget
+    directory: "/src"
+    schedule:
+      interval: daily
+      time: "11:00"
+    groups:
+      nuget-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      microsoft-packages:
+        patterns:
+          - "Microsoft.*"
+          - "System.*"
+        update-types:
+          - "major"
 
-- package-ecosystem: nuget
-  directory: "/.config"
-  schedule:
-    interval: daily
-    time: "11:00"
+  - package-ecosystem: nuget
+    directory: "/.config"
+    schedule:
+      interval: daily
+      time: "11:00"
+    groups:
+      build-tools:
+        patterns:
+          - "*"
 
-- package-ecosystem: dotnet-sdk
-  directory: "/src"
-  schedule:
-    interval: daily
-    time: "11:00"
+  - package-ecosystem: dotnet-sdk
+    directory: "/src"
+    schedule:
+      interval: daily
+      time: "11:00"


### PR DESCRIPTION
Configures Dependabot to group dependencies for more manageable updates.

This change introduces groups for GitHub Actions, NuGet packages (minor/patch and Microsoft packages), and build tools. This allows for more granular control over dependency updates and reduces noise from frequent updates.