### PR TITLE
Removes snupkg artifact upload

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -113,9 +113,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: nuget-packages
-          path: |
-            ${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.nupkg
-            ${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.snupkg
+          path: ${{ env.PACKAGE_OUTPUT_DIRECTORY }}/*.nupkg
 
   publish:
     permissions:

--- a/src/Signal.Bot/Signal.Bot.csproj
+++ b/src/Signal.Bot/Signal.Bot.csproj
@@ -20,8 +20,6 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <DebugType>embedded</DebugType>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
     <ItemGroup>
         <None Include="../../README.md" Pack="true" Visible="false" PackagePath="\"/>


### PR DESCRIPTION
Removes the generation and uploading of symbol packages (.snupkg) during the build and release process.

These packages are no longer required, simplifying the release pipeline.